### PR TITLE
Persist analysis outputs to DynamoDB

### DIFF
--- a/aws/analyze_file/file_processor.py
+++ b/aws/analyze_file/file_processor.py
@@ -39,7 +39,7 @@ def download_file_from_s3(bucket_name: str, original_key: str) -> str:
     return local_path, file_name, file_ext
 
 
-def upload_files_to_s3(file_paths: List[str]) -> List[dict]:
+def upload_files_to_s3(file_paths: List[str],bucket,key) -> List[dict]:
     """
     Uploads a list of local file paths to S3 with safe UUID-based keys.
     Returns: List of metadata dicts per file uploaded
@@ -53,16 +53,15 @@ def upload_files_to_s3(file_paths: List[str]) -> List[dict]:
 
         filename = os.path.basename(path)
         extension = os.path.splitext(filename)[1]
-        processed_key = f"{FileConfig.EXTRACT_PREFIX}{uuid.uuid4()}{extension}"
 
         try:
-            print(f"[UPLOAD] Uploading {path} to s3://{FileConfig.S3_BUCKET}/{processed_key}")
-            s3_client.upload_file(path, FileConfig.S3_BUCKET, processed_key)
-            print(f"[SUCCESS] Uploaded to: {processed_key}")
+            print(f"[UPLOAD] Uploading {path} to s3://{FileConfig.S3_BUCKET}/{key}")
+            s3_client.upload_file(path, bucket, key)
+            print(f"[SUCCESS] Uploaded to: {key}")
 
             uploaded_files.append({
                 'local_path': path,
-                'image_path': processed_key,
+                'image_path': key,
             })
         except Exception as e:
             print(f"[ERROR] Upload failed for {path}: {e}")

--- a/aws/common/utilities/dynamodb_manager.py
+++ b/aws/common/utilities/dynamodb_manager.py
@@ -1,0 +1,80 @@
+import json
+import os
+from typing import Any, Dict
+
+import boto3
+from botocore.exceptions import ClientError
+
+from aws.common.utilities.logger_manager import LoggerManager
+
+_DYNAMODB_LOGGER = LoggerManager.get_module_logger("DynamoDBManager")
+
+
+class DynamoDBManager:
+    """Minimal DynamoDB helper for persisting analysis results.
+
+    Attributes
+    ----------
+    labels_table : boto3.resources.factory.dynamodb.Table
+        Table for document labels.
+    checks_table : boto3.resources.factory.dynamodb.Table
+        Table for document check results.
+    """
+
+    def __init__(self, region_name: str | None = None) -> None:
+        resource = boto3.resource("dynamodb", region_name=region_name)
+        labels_table_name = os.getenv("DDB_LABELS_TABLE", "document-labels")
+        checks_table_name = os.getenv("DDB_CHECKS_TABLE", "document-check-results")
+        self.labels_table = resource.Table(labels_table_name)
+        self.checks_table = resource.Table(checks_table_name)
+        _DYNAMODB_LOGGER.info(
+            "Initialized DynamoDB tables: labels=%s, checks=%s",
+            labels_table_name,
+            checks_table_name,
+        )
+
+    def save_labels(
+        self,
+        *,
+        file_type: str,
+        doc_id: str,
+        s3_path: str,
+        labels: Dict[str, Any],
+    ) -> None:
+        """Persist extracted label data in DynamoDB.
+
+        Parameters
+        ----------
+        file_type: str
+            Document type used as the partition key.
+        doc_id: str
+            Unique document identifier (sort key).
+        s3_path: str
+            Full S3 key of the uploaded file.
+        labels: Dict[str, Any]
+            Extracted label data to persist.
+        """
+        item = {
+            "file_type": file_type,
+            "doc_id": doc_id,
+            "s3_path": s3_path,
+            "labels": labels,
+        }
+        try:
+            self.labels_table.put_item(Item=item)
+        except ClientError as exc:
+            _DYNAMODB_LOGGER.error("Failed to store labels: %s", exc)
+
+    def save_check_results(
+        self, *, file_type: str, doc_id: str, fraud_report_json: str
+    ) -> None:
+        """Persist fraud report JSON in DynamoDB."""
+        item = {
+            "file_type": file_type,
+            "doc_id": doc_id,
+            "checks": json.loads(fraud_report_json),
+        }
+        try:
+            self.checks_table.put_item(Item=item)
+        except ClientError as exc:
+            _DYNAMODB_LOGGER.error("Failed to store check results: %s", exc)

--- a/aws/common/utilities/dynamodb_manager.py
+++ b/aws/common/utilities/dynamodb_manager.py
@@ -39,6 +39,7 @@ class DynamoDBManager:
         file_type: str,
         doc_id: str,
         s3_path: str,
+        bucket: str,
         labels: Dict[str, Any],
     ) -> None:
         """Persist extracted label data in DynamoDB.
@@ -58,6 +59,7 @@ class DynamoDBManager:
             "file_type": file_type,
             "doc_id": doc_id,
             "s3_path": s3_path,
+            "bucket": bucket,
             "labels": labels,
         }
         try:
@@ -66,12 +68,19 @@ class DynamoDBManager:
             _DYNAMODB_LOGGER.error("Failed to store labels: %s", exc)
 
     def save_check_results(
-        self, *, file_type: str, doc_id: str, fraud_report_json: str
+        self, *,
+        file_type: str,
+        doc_id: str,
+        s3_path: str,
+        bucket: str,
+        fraud_report_json: str
     ) -> None:
         """Persist fraud report JSON in DynamoDB."""
         item = {
             "file_type": file_type,
             "doc_id": doc_id,
+            "s3_path": s3_path,
+            "bucket": bucket,
             "checks": json.loads(fraud_report_json),
         }
         try:


### PR DESCRIPTION
## Summary
- Add DynamoDBManager utility for storing document labels and check results
- Store label data (including S3 path) and fraud report outputs in DynamoDB during processing
- Pass S3 keys to processing pipeline for persistence

## Testing
- `python -m py_compile analyze_file/lambda_function.py common/utilities/dynamodb_manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a45dda9a908322a3f7e792002efc7c